### PR TITLE
fix ios crash on capture

### DIFF
--- a/ios/RNPdfScannerManager.m
+++ b/ios/RNPdfScannerManager.m
@@ -11,11 +11,6 @@
 
 @implementation RNPdfScannerManager
 
-- (dispatch_queue_t)methodQueue
-{
-    return dispatch_get_main_queue();
-}
-
 RCT_EXPORT_MODULE()
 
 RCT_EXPORT_VIEW_PROPERTY(onPictureTaken, RCTBubblingEventBlock)


### PR DESCRIPTION
this was caused by the original and non idiomatic way to call capture and was overlooked when capture and view got fixed